### PR TITLE
Fix the 500 errorpage if sentry/raven is not installed or activated

### DIFF
--- a/imagetagger/imagetagger/base/templates/500.html
+++ b/imagetagger/imagetagger/base/templates/500.html
@@ -1,28 +1,40 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
-{% load raven %} {# TODO: nur wen raven/sentry aktiviert ist #}
+{% load friendly_loader %}
+{% friendly_load raven %}
+
 {% block wtitle %}{% block ptitle %}{% trans "Internal server error" %}{% endblock %}{% endblock %}
 {% block headJS %}<script src="{% static 'scripts/raven.min.js' %}"></script>{% endblock %}
-{% sentry_public_dsn 'https' %}
+
+{% if_has_tag sentry_public_dsn %}
+        {% sentry_public_dsn 'https' %}
+{% endif_has_tag %}
+
 {% block content %}
-<script>Raven.config('{% sentry_public_dsn %}').install()</script>
+    {% if_has_tag sentry_public_dsn %}
+        {% if request.sentry %}
+            <script>Raven.config('{% sentry_public_dsn %}').install()</script>
+        {% endif %}
+    {% endif_has_tag %}
 {% url 'base_problems' as problems_url %}
     <div class="container"><section class="section">
     <div class="col-md-5">
     <h1>Internal Server Error (500)</h1>
 <p>{% blocktrans %}We're sorry, but we didn't expect this to happen. Our error reporting tool should have sent an email to us with some technical details. Please try again later. If the problem persists, see our <a href="{{ problems_url }}">problem reporting page</a>.{% endblocktrans %}</p>
-    {% if request.sentry.id %}
-        {% with request.sentry.id as errorid %}
-            <p>{% blocktrans %}We have recorded the error under the Identifier {{ errorid }}.{% endblocktrans %}</p>
-            <script >
-                Raven.showReportDialog({
-                    eventId: '{{ errorid }}',
-                    dsn: '{% sentry_public_dsn %}'
-                });{# TODO: User ausfüllen wen angemeldet? #}
-            </script>
-        {% endwith %}
-    {% endif %}
+    {% if_has_tag sentry_public_dsn %}
+        {% if request.sentry.id %}
+            {% with request.sentry.id as errorid %}
+                <p>{% blocktrans %}We have recorded the error under the Identifier {{ errorid }}.{% endblocktrans %}</p>
+                <script>
+                    Raven.showReportDialog({
+                        eventId: '{{ errorid }}',
+                        dsn: '{% sentry_public_dsn %}'
+                    });{# TODO: User ausfüllen wen angemeldet? #}
+                </script>
+            {% endwith %}
+        {% endif %}
+    {% endif_has_tag %}
     </div><div class="col-md-offset-1 col-md-5"><img src="{% static 'symbols/server-Bit.png' %}"></div>
 </section> </div>
 {% endblock %}

--- a/imagetagger/imagetagger/base/templates/500.html
+++ b/imagetagger/imagetagger/base/templates/500.html
@@ -4,24 +4,26 @@
 {% load friendly_loader %}
 {% friendly_load raven %}
 
-{% block wtitle %}{% block ptitle %}{% trans "Internal server error" %}{% endblock %}{% endblock %}
-{% block headJS %}<script src="{% static 'scripts/raven.min.js' %}"></script>{% endblock %}
-
 {% if_has_tag sentry_public_dsn %}
-        {% sentry_public_dsn 'https' %}
+    {% block additional_js %}<script src="{% static 'scripts/raven.min.js' %}"></script>{% endblock %}
+    {% sentry_public_dsn 'https' %}
 {% endif_has_tag %}
 
-{% block content %}
+{% block bodyblock %}
     {% if_has_tag sentry_public_dsn %}
         {% if request.sentry %}
             <script>Raven.config('{% sentry_public_dsn %}').install()</script>
         {% endif %}
     {% endif_has_tag %}
-{% url 'base_problems' as problems_url %}
     <div class="container"><section class="section">
     <div class="col-md-5">
     <h1>Internal Server Error (500)</h1>
-<p>{% blocktrans %}We're sorry, but we didn't expect this to happen. Our error reporting tool should have sent an email to us with some technical details. Please try again later. If the problem persists, see our <a href="{{ problems_url }}">problem reporting page</a>.{% endblocktrans %}</p>
+    <p>
+        {% trans "We're sorry, but we didn't expect this to happen." %}
+        {% if_has_tag sentry_public_dsn %}{% trans "Our error reporting tool should have sent an email to us with some technical details." %}{% endif_has_tag %}
+        {% trans "Please try again later." %}
+        {% trans "If the problem persists, see our" %} <a href="{% url 'base:problem' %}">{% trans "problem reporting page" %}</a>.
+    </p>
     {% if_has_tag sentry_public_dsn %}
         {% if request.sentry.id %}
             {% with request.sentry.id as errorid %}
@@ -35,7 +37,6 @@
             {% endwith %}
         {% endif %}
     {% endif_has_tag %}
-    </div><div class="col-md-offset-1 col-md-5"><img src="{% static 'symbols/server-Bit.png' %}"></div>
+    </div><div class="col-md-offset-1 col-md-5"><img src="{% static 'symbols/server-Bit.png' %}" style="width: 100%;"></div>
 </section> </div>
 {% endblock %}
-

--- a/imagetagger/imagetagger/base/templates/base/base.html
+++ b/imagetagger/imagetagger/base/templates/base/base.html
@@ -67,7 +67,7 @@
                     <a target="_blank" href="https://github.com/bit-bots/imagetagger">
                         This project on GitHub
                     </a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a target="_blank" href="https://github.com/bit-bots/imagetagger/issues">
+                    <a target="_blank" href="{% url 'base:problem' %}">
                         Report an issue
                     </a>&nbsp;&nbsp;&nbsp;&nbsp;
                     {% if USE_IMPRINT %}
@@ -78,10 +78,6 @@
         </footer>
         <script type="text/javascript" src="{% static 'scripts/jquery-3.2.1.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'scripts/bootstrap.min.js' %}"></script>
-        <script type="text/javascript">
-            {# TODO: This block is deprecated. Should be within additional_js (or, actually, there should not be any inline javascript usage at all!) #}
-            {% block individual_script %}{% endblock individual_script %}
-        </script>
         {% block additional_js %}{% endblock additional_js %}
     </body>
 </html>

--- a/imagetagger/imagetagger/base/templates/base/problem.html
+++ b/imagetagger/imagetagger/base/templates/base/problem.html
@@ -1,0 +1,11 @@
+{% extends "base/base.html" %}
+{% load static %}
+
+{% block bodyblock %}
+    <div class="container"><section class="section">
+        <div class="col-md-5">
+            <h1>Report a problem</h1>
+            <p>{{ text }}</p>
+        </div>
+    </section> </div>
+{% endblock %}

--- a/imagetagger/imagetagger/base/urls.py
+++ b/imagetagger/imagetagger/base/urls.py
@@ -5,4 +5,5 @@ from . import views
 app_name = 'base'
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^problems/$', views.problem_report, name='problem')
 ]

--- a/imagetagger/imagetagger/base/views.py
+++ b/imagetagger/imagetagger/base/views.py
@@ -1,6 +1,16 @@
-from django.shortcuts import redirect
+from django.conf import settings
+from django.shortcuts import redirect, render
 from django.urls import reverse
 
 
 def index(request):
     return redirect(reverse('images:index'))
+
+
+def problem_report(request):
+    if settings.PROBLEMS_TEXT is not '':
+        return render(request, 'base/problem.html', {
+            'text': settings.PROBLEMS_TEXT
+        })
+    else:
+        return redirect(settings.PROBLEMS_URL)

--- a/imagetagger/imagetagger/settings.py.example
+++ b/imagetagger/imagetagger/settings.py.example
@@ -54,6 +54,10 @@ LANGUAGE_CODE = 'en-us'
 
 USE_NGINX_IMAGE_PROVISION = False  # defines if images get provided directly via nginx what generally improves imageset download performance
 
+# The 'report a problem' page on an internal server error can either be a custom url or a text that can be defined here.
+# PROBLEMS_URL = 'https://problems.example.com'
+# PROBLEMS_TEXT = 'To report a problem, contact admin@example.com'
+
 USE_IMPRINT = False
 IMPRINT_NAME = ''
 IMPRINT_URL = ''

--- a/imagetagger/imagetagger/settings_base.py
+++ b/imagetagger/imagetagger/settings_base.py
@@ -113,6 +113,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+PROBLEMS_URL = 'https://github.com/bit-bots/imagetagger/issues'
+PROBLEMS_TEXT = ''
 
 LOGIN_URL = '/user/login/'
 LOGIN_REDIRECT_URL = '/images/'

--- a/imagetagger/imagetagger/settings_base.py
+++ b/imagetagger/imagetagger/settings_base.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'widget_tweaks',
+    'friendlytagloader',
 ]
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ django-widget-tweaks
 Pillow
 psycopg2-binary
 django-registration
+django-friendly-tag-loader


### PR DESCRIPTION
This imports the fix from fsinfuhh/bitpoll#28 If raven is not installed
or not loaded the parts asking vor feedback will be ignored via
django-friendly-tag-loader