### PR TITLE
Add checkboxes for blurred and concealed to verification view

### DIFF
--- a/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
@@ -110,8 +110,6 @@ function calculateImageScale() {
     if (state) {
       strState = 'accept';
     }
-    let blurred = $('#blurred').is(':checked');
-    let concealed = $('#concealed').is(':checked');
     let annotation = gAnnotationList.filter(function(e) {
       return e.id === id;
     })[0];
@@ -119,8 +117,6 @@ function calculateImageScale() {
     let data = {
       annotation_id: id,
       state: strState,
-      concealed: concealed,
-      blurred: blurred
     };
     $.ajax(API_ANNOTATIONS_BASE_URL + 'annotation/verify/', {
       type: 'POST',
@@ -129,8 +125,6 @@ function calculateImageScale() {
       data: JSON.stringify(data),
       success: function (data) {
         displayFeedback($('#feedback_verify_successful'));
-        annotation.concealed = concealed;
-        annotation.blurred = blurred;
       },
       error: function () {
         displayFeedback($('#feedback_connection_error'));
@@ -487,7 +481,6 @@ function calculateImageScale() {
 
   function handleFilterSwitchChange() {
     loadFilteredAnnotationList(gImageSetId);
-
   }
 
   function handleAnnotationTypeSelectChange() {
@@ -505,6 +498,7 @@ function calculateImageScale() {
       $('#concealed_label').hide()
     }
     drawAnnotation(annotation);
+    apiBlurredConcealed();
   }
 
   function handleBlurredChange() {
@@ -518,6 +512,30 @@ function calculateImageScale() {
       $('#blurred_label').hide()
     }
     drawAnnotation(annotation);
+    apiBlurredConcealed();
+  }
+
+  function apiBlurredConcealed() {
+    let annotation = gAnnotationList.filter(function(e) {
+      return e.id === gAnnotationId;
+    })[0];
+    let data = {
+      annotation_id: annotation.id,
+      blurred: annotation.blurred,
+      concealed: annotation.concealed
+    };
+    $.ajax(API_ANNOTATIONS_BASE_URL + 'annotation/blurred_concealed/', {
+      method: 'POST',
+      headers: gHeaders,
+      dataType: 'json',
+      data: JSON.stringify(data),
+      success: function() {
+        displayFeedback($('#feedback_update_successful'));
+      },
+      error: function() {
+        displayFeedback($('#feedback_connection_error'));
+      }
+    });
   }
 
   $(function() {

--- a/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
@@ -110,13 +110,17 @@ function calculateImageScale() {
     if (state) {
       strState = 'accept';
     }
+    let blurred = $('#blurred').is(':checked');
+    let concealed = $('#concealed').is(':checked');
     let annotation = gAnnotationList.filter(function(e) {
       return e.id === id;
     })[0];
     annotation.verified_by_user = true;
     let data = {
       annotation_id: id,
-      state: strState
+      state: strState,
+      concealed: concealed,
+      blurred: blurred
     };
     $.ajax(API_ANNOTATIONS_BASE_URL + 'annotation/verify/', {
       type: 'POST',
@@ -125,6 +129,8 @@ function calculateImageScale() {
       data: JSON.stringify(data),
       success: function (data) {
         displayFeedback($('#feedback_verify_successful'));
+        annotation.concealed = concealed;
+        annotation.blurred = blurred;
       },
       error: function () {
         displayFeedback($('#feedback_connection_error'));
@@ -299,8 +305,13 @@ function calculateImageScale() {
     }
 
     annotationIndex += offset;
-    if (annotationIndex < 0 || annotationIndex >= annotationIndexList.length) {
+    if (annotationIndex < 0) {
       displayFeedback($('#feedback_last_annotation'));
+      drawAnnotation(gAnnotationList[0]);
+      return;
+    } else if (annotationIndex >= annotationIndexList.length) {
+      displayFeedback($('#feedback_last_annotation'));
+      drawAnnotation(gAnnotationList[gAnnotationList.length - 1]);
       return;
     }
 
@@ -357,11 +368,13 @@ function calculateImageScale() {
     } else {
       $('#concealed_label').hide()
     }
+    $('#concealed').prop('checked', annotation.concealed);
     if (annotation.blurred) {
       $('#blurred_label').show()
     } else {
       $('#blurred_label').hide()
     }
+    $('#blurred').prop('checked', annotation.blurred);
     drawAnnotation(annotation);
   }
 
@@ -479,7 +492,32 @@ function calculateImageScale() {
 
   function handleAnnotationTypeSelectChange() {
     loadFilteredAnnotationList(gImageSetId);
+  }
 
+  function handleConcealedChange() {
+    let annotation = gAnnotationList.filter(function(e) {
+      return e.id === gAnnotationId;
+    })[0];
+    annotation.concealed = $('#concealed').is(':checked');
+    if (annotation.concealed) {
+      $('#concealed_label').show()
+    } else {
+      $('#concealed_label').hide()
+    }
+    drawAnnotation(annotation);
+  }
+
+  function handleBlurredChange() {
+    let annotation = gAnnotationList.filter(function(e) {
+      return e.id === gAnnotationId;
+    })[0];
+    annotation.blurred = $('#blurred').is(':checked');
+    if (annotation.blurred) {
+      $('#blurred_label').show()
+    } else {
+      $('#blurred_label').hide()
+    }
+    drawAnnotation(annotation);
   }
 
   $(function() {
@@ -525,6 +563,8 @@ function calculateImageScale() {
     $('#next_button').click(function(event) {
       loadAdjacentAnnotation(1);
     });
+    $('#concealed').click(handleConcealedChange);
+    $('#blurred').click(handleBlurredChange);
     $('.js_feedback').mouseover(function() {
       $(this).addClass('hidden');
     });
@@ -545,6 +585,12 @@ function calculateImageScale() {
           break;
         case 75: //k
           $('#reject_button').click();
+          break;
+        case 66: //b
+          $('#blurred').click();
+          break;
+        case 67: //c
+          $('#concealed').click();
           break;
       }
     });

--- a/imagetagger/imagetagger/annotations/templates/annotations/verification.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/verification.html
@@ -43,14 +43,24 @@
         </div>
         <div class="col-sm-3 col-sm-push-3">
             <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 id="annotation-type-title" class="panel-title"></h3>
+                    <div id="labels">
+                        <span id="blurred_label" class="label label-info">Blurred</span>
+                        <span id="concealed_label" class="label label-warning">Concealed</span>
+                    </div>
+                </div>
                 <div class="panel-body" id="verification_form">
                     <div class="row">
                         <div class="col-md-12">
-                            <h4 id="annotation-type-title"></h4>
-                            <p id="labels">
-                                <span id="blurred_label" class="label label-info">Blurred</span>
-                                <span id="concealed_label" class="label label-warning">Concealed</span>
-                            </p>
+                            <div id='concealed_p'>
+                                <input type='checkbox' id='concealed' name="concealed">
+                                <label for='concealed'>concealed (c)</label>
+                            </div>
+                            <div id='blurred_p'>
+                                <input type='checkbox' id='blurred' name="blurred">
+                                <label for='blurred'>blurred (b)</label>
+                            </div>
                         </div>
                         <div class="col-md-6 col-md-offset-6 hidden-xs">
                             <button class="btn btn-warning btn-block" type='button' id='edit_button'>

--- a/imagetagger/imagetagger/annotations/templates/annotations/verification.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/verification.html
@@ -28,6 +28,9 @@
     <div id="feedback_verify_successful" class="js_feedback alert alert-success hidden">
         {% trans 'The annotation has been verified.' %}
     </div>
+    <div id="feedback_update_successful" class="js_feedback alert alert-success hidden">
+        {% trans 'The annotation has been updated.' %}
+    </div>
     <div id="feedback_last_annotation" class="js_feedback alert alert-danger hidden">
         {% trans 'There are no more annotations in the list.' %}
     </div>

--- a/imagetagger/imagetagger/annotations/urls.py
+++ b/imagetagger/imagetagger/annotations/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     url(r'^api/annotation/loadone/$', views.load_annotation, name='load_annotation'),
     url(r'^api/annotation/verify/$', views.api_verify_annotation, name='verify_annotation'),
     url(r'^api/annotation/update/$', views.update_annotation, name='update_annotations'),
+    url(r'^api/annotation/blurred_concealed/$', views.api_blurred_concealed_annotation, name='blurred_concealed_annotation'),
 ]

--- a/imagetagger/imagetagger/annotations/views.py
+++ b/imagetagger/imagetagger/annotations/views.py
@@ -859,6 +859,8 @@ def api_verify_annotation(request) -> Response:
             state = False
         else:
             raise ParseError
+        concealed = request.data['concealed']
+        blurred = request.data['blurred']
 
     except (KeyError, TypeError, ValueError):
         raise ParseError
@@ -871,7 +873,11 @@ def api_verify_annotation(request) -> Response:
         }, status=HTTP_403_FORBIDDEN)
 
     if state:
-        annotation.verify(request.user, True)
+        with transaction.atomic():
+            annotation._concealed = concealed
+            annotation._blurred = blurred
+            annotation.save()
+            annotation.verify(request.user, True)
         if Verification.objects.filter(
                 user=request.user,
                 verified=state,


### PR DESCRIPTION
This pull request closes issue #66. 

I am not sure, if the verifications of a annotation should be reset to one after the change of a concealed/blurred attribute. What do you think @NFiedler?