### PR TITLE
Revert "Validate ZIP files by magic number instead of file extension"

### DIFF
--- a/imagetagger/imagetagger/images/views.py
+++ b/imagetagger/imagetagger/images/views.py
@@ -189,7 +189,8 @@ def upload_image(request, imageset_id):
                 'unsupported': False,
                 'zip': False,
             }
-            if f.peek(4) == b'PK\x03\x04':  # ZIP file magic number
+            fname = f.name.split('.')
+            if fname[-1] == 'zip':
                 error['zip'] = True
                 zipname = ''.join(random.choice(string.ascii_uppercase +
                                                 string.ascii_lowercase +
@@ -266,7 +267,6 @@ def upload_image(request, imageset_id):
                 # tests for duplicats in  imageset
                 if Image.objects.filter(checksum=fchecksum, image_set=imageset)\
                         .count() == 0:
-                    fname = f.name.split('.')
                     fname = ('_'.join(fname[:-1]) + '_' +
                              ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
                                      for _ in range(6)) + '.' + fname[-1])


### PR DESCRIPTION
The peek method does not exist on `InMemoryUploadedFile` and `TemporaryUploadedFile`. This reverts the causing commit until a better solution is found.

This reverts commit c2960665c4b467fbdb1cb7528669826b89fa74bc.

This pull request closes #121.