### PR TITLE
Fix variable name usage: imageset.image_lock is now imageset_lock

### DIFF
--- a/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
@@ -252,7 +252,6 @@
                               </div>
                             {% endif %}
                             {% if 'delete_images' in imageset_perms and not imageset_lock %}
-                            <div class="col-sm-12"><p>{{ imageset_lock }}</p></div>
                             <div class="col-md-12">
                                 <button type="button" class="btn btn-danger" id="delete-button" data-toggle="modal" data-target="#deleteModal" style="width: 100%">
                                     <span class="glyphicon glyphicon-trash" aria-hidden="true" style="padding-right: 3px;"></span>Remove image from imageset

--- a/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
@@ -252,6 +252,7 @@
                               </div>
                             {% endif %}
                             {% if 'delete_images' in imageset_perms and not imageset_lock %}
+                            <div class="col-sm-12"><p></p></div>
                             <div class="col-md-12">
                                 <button type="button" class="btn btn-danger" id="delete-button" data-toggle="modal" data-target="#deleteModal" style="width: 100%">
                                     <span class="glyphicon glyphicon-trash" aria-hidden="true" style="padding-right: 3px;"></span>Remove image from imageset

--- a/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/annotate.html
@@ -252,7 +252,7 @@
                               </div>
                             {% endif %}
                             {% if 'delete_images' in imageset_perms and not imageset_lock %}
-                            <div class="col-sm-12"><p>{{ imageset.image_lock }}</p></div>
+                            <div class="col-sm-12"><p>{{ imageset_lock }}</p></div>
                             <div class="col-md-12">
                                 <button type="button" class="btn btn-danger" id="delete-button" data-toggle="modal" data-target="#deleteModal" style="width: 100%">
                                     <span class="glyphicon glyphicon-trash" aria-hidden="true" style="padding-right: 3px;"></span>Remove image from imageset


### PR DESCRIPTION
Looking at the view variables, this was changed to be passed in as a different name and never updated.