### PR TITLE
Update postgres initialization documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ The following settings should probably be changed:
 + The database settings
 + The UPLOAD\_FS\_GROUP to the id of the group that should access and create the uploaded images
 
-For the database, postgresql is used. Install it by running `sudo apt install postgresql`
+For the database, postgresql is used. Install it by running `sudo apt install postgresql` on debian based operating systems. A default database cluster is automatically initialized.
 
-Initialize the database cluster with `sudo -iu postgres initdb --locale en_US.UTF-8 -D '/var/lib/postgres/data'`
+Other systems may require different commands to install the package and the database cluster may
+have to be initialized manually (e.g. using `sudo -iu postgres initdb --locale en_US.UTF-8 -D '/var/lib/postgres/data'`).
 
 To start the postgresql server, run `sudo systemctl start postgresql.service`. If the server should always be started on boot, run `sudo systemctl enable postgresql.service`.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following settings should probably be changed:
 + The database settings
 + The UPLOAD\_FS\_GROUP to the id of the group that should access and create the uploaded images
 
-For the database, postgresql is used. Install it by running `sudo apt install postgresql` on debian based operating systems. A default database cluster is automatically initialized.
+For the database, postgresql is used. Install it by running `sudo apt install postgresql` on Debian based operating systems. A default database cluster is automatically initialized.
 
 Other systems may require different commands to install the package and the database cluster may
 have to be initialized manually (e.g. using `sudo -iu postgres initdb --locale en_US.UTF-8 -D '/var/lib/postgres/data'`).


### PR DESCRIPTION
As suggested in #136, the current documentation includes the initialization of the database cluster which is not necessary on debian based systems.