### PR TITLE
Rewrite of storage backend using fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM docker.io/debian:buster-slim
 # install imagetagger system dependencies
 RUN apt-get update && \
 	apt-get install --no-install-recommends -y g++ wget uwsgi-plugin-python3 python3 python3-pip node-uglify make git \
-	    python3-psycopg2 python3-ldap3 gettext gcc python3-dev python3-setuptools libldap2-dev libsasl2-dev nginx
+	    python3-psycopg2 python3-ldap3 python3-pkg-resources gettext gcc python3-dev python3-setuptools libldap2-dev \
+	    libsasl2-dev nginx
 
 # add requirements file
 WORKDIR /app/src

--- a/imagetagger/imagetagger/base/filesystem.py
+++ b/imagetagger/imagetagger/base/filesystem.py
@@ -1,0 +1,21 @@
+import fs
+import fs.base
+from django.conf import settings
+
+
+def root() -> fs.base.FS:
+    """Get the root filesystem object or create one by opening `settings.FS_URL`."""
+    if root._instance is None:
+        root._instance = fs.open_fs(settings.FS_URL)
+    return root._instance
+
+root._instance = None
+
+
+def tmp() -> fs.base.FS:
+    """Get the tmp filesystem object or create one by opening `settings.TMP_FS_URL`."""
+    if tmp._instance is None:
+        tmp._instance = fs.open_fs(settings.TMP_FS_URL)
+    return tmp._instance
+
+tmp._instance = None

--- a/imagetagger/imagetagger/images/management/commands/runzipdaemon.py
+++ b/imagetagger/imagetagger/images/management/commands/runzipdaemon.py
@@ -39,10 +39,12 @@ class Command(BaseCommand):
             return
 
         tmp_zip_path = imageset.tmp_zip_path()
+        if not tmp().exists(path.dirname(tmp_zip_path)):
+            tmp().makedirs(path.dirname(tmp_zip_path))
         with tmp().open(tmp_zip_path, 'wb') as zip_file:
             with WriteZipFS(zip_file) as zip_fs:
                 for image in imageset.images.all():
-                    root().download(image.path(), zip_fs.open(image.name, 'wb'))
+                    root().download(image.path(), zip_fs.openbin(image.name, 'w'))
         with tmp().open(tmp_zip_path, 'rb') as zip_file:
             root().upload(imageset.zip_path(), zip_file)
         tmp().remove(tmp_zip_path)

--- a/imagetagger/imagetagger/images/management/commands/runzipdaemon.py
+++ b/imagetagger/imagetagger/images/management/commands/runzipdaemon.py
@@ -1,13 +1,14 @@
 import fasteners
-import os
+from fs import path
+from fs.zipfs import WriteZipFS
 from time import sleep
 
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.db.models import Q
-from zipfile import ZipFile
 
 from imagetagger.images.models import ImageSet
+from imagetagger.base.filesystem import root, tmp
 
 
 class Command(BaseCommand):
@@ -17,7 +18,7 @@ class Command(BaseCommand):
         if not settings.ENABLE_ZIP_DOWNLOAD:
             raise CommandError('To enable zip download, set ENABLE_ZIP_DOWNLOAD to True in settings.py')
 
-        lock = fasteners.InterProcessLock(os.path.join(settings.IMAGE_PATH, 'zip.lock'))
+        lock = fasteners.InterProcessLock(path.combine(settings.IMAGE_PATH, 'zip.lock'))
         gotten = lock.acquire(blocking=False)
         if gotten:
             while True:
@@ -37,12 +38,14 @@ class Command(BaseCommand):
             self.stderr.write('skipping regeneration of ready imageset {}'.format(imageset.name))
             return
 
-        with ZipFile(os.path.join(settings.IMAGE_PATH, imageset.tmp_zip_path()), 'w') as f:
-            for image in imageset.images.all():
-                f.write(image.path(), image.name)
-
-        os.rename(os.path.join(settings.IMAGE_PATH, imageset.tmp_zip_path()),
-                  os.path.join(settings.IMAGE_PATH, imageset.zip_path()))
+        tmp_zip_path = imageset.tmp_zip_path()
+        with tmp().open(tmp_zip_path, 'wb') as zip_file:
+            with WriteZipFS(zip_file) as zip_fs:
+                for image in imageset.images.all():
+                    root().download(image.path(), zip_fs.open(image.name, 'wb'))
+        with tmp().open(tmp_zip_path, 'rb') as zip_file:
+            root().upload(imageset.zip_path(), zip_file)
+        tmp().remove(tmp_zip_path)
 
         # Set state to ready if image set has not been set to invalid during regeneration
         ImageSet.objects.filter(pk=imageset.pk, zip_state=ImageSet.ZipState.PROCESSING) \

--- a/imagetagger/imagetagger/images/models.py
+++ b/imagetagger/imagetagger/images/models.py
@@ -1,9 +1,9 @@
 from typing import Set
 
+from fs import path
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
-import os
 
 from imagetagger.users.models import Team
 
@@ -19,10 +19,10 @@ class Image(models.Model):
     height = models.IntegerField(default=600)
 
     def path(self):
-        return os.path.join(self.image_set.root_path(), self.filename)
+        return path.combine(self.image_set.root_path(), self.filename)
 
     def relative_path(self):
-        return os.path.join(self.image_set.path, self.filename)
+        return path.combine(self.image_set.path, self.filename)
 
     def delete(self, *args, **kwargs):
         self.image_set.zip_state = ImageSet.ZipState.INVALID
@@ -92,16 +92,22 @@ class ImageSet(models.Model):
     zip_state = models.IntegerField(choices=ZIP_STATES, default=ZipState.INVALID)
 
     def root_path(self):
-        return os.path.join(settings.IMAGE_PATH, self.path)
+        return path.combine(settings.IMAGE_PATH, self.path)
+
+    def tmp_path(self):
+        return path.combine(settings.TMP_IMAGE_PATH, self.path)
+
+    def relative_zip_path(self):
+        return path.combine(self.path, self.zip_name())
 
     def zip_path(self):
-        return os.path.join(self.path, self.zip_name())
+        return path.combine(self.root_path(), self.zip_name())
+
+    def tmp_zip_path(self):
+        return path.combine(self.tmp_path(), self.zip_name())
 
     def zip_name(self):
         return "imageset_{}.zip".format(self.id)
-
-    def tmp_zip_path(self):
-        return os.path.join(self.path, ".tmp." + self.zip_name())
 
     @property
     def image_count(self):

--- a/imagetagger/imagetagger/settings.py.example
+++ b/imagetagger/imagetagger/settings.py.example
@@ -1,5 +1,5 @@
 from .settings_base import *
-import os
+from fs import path
 
 # Settings for Imagetagger
 # Copy this file as settings.py and customise as necessary
@@ -42,9 +42,9 @@ LANGUAGE_CODE = 'en-us'
 STATIC_ROOT = '/var/www/imagetagger'
 
 # EXPORT_SEPARATOR = '|'
-# DATA_PATH = os.path.join(BASE_DIR, 'data')
 
-# IMAGE_PATH = os.path.join(BASE_DIR, 'images')  # the absolute path to the folder with the imagesets
+# IMAGE_PATH = 'images'  # the path to the folder with the imagesets relative to the filesystem root (see FS_URL)
+# TMP_IMAGE_PATH = 'images'  # the path to use for temporary image files relative to the temp filesystem (see TMP_FS_URL)
 
 # filename extension of accepted imagefiles
 # IMAGE_EXTENSION = {

--- a/imagetagger/imagetagger/settings.py.example
+++ b/imagetagger/imagetagger/settings.py.example
@@ -78,9 +78,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 TOOLS_ENABLED = True
 TOOL_UPLOAD_NOTICE = ''
 
-DATA_PATH = '/app/data'
-IMAGE_PATH = DATA_PATH + '/images'
-TOOLS_PATH = DATA_PATH + '/tools'
+IMAGE_PATH = 'images'
+TOOLS_PATH = 'tools'
 
 # Use ldap login
 #

--- a/imagetagger/imagetagger/settings_base.py
+++ b/imagetagger/imagetagger/settings_base.py
@@ -13,15 +13,13 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 import os
 from django.contrib.messages import constants as messages
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+FS_URL = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TMP_FS_URL = 'temp://imagetagger'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -133,11 +131,15 @@ MESSAGE_TAGS = {
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = 'static/'
 
 EXPORT_SEPARATOR = '|'
-DATA_PATH = os.path.join(BASE_DIR, 'data')
 
-IMAGE_PATH = os.path.join(BASE_DIR, 'images')  # the absolute path to the folder with the imagesets
+IMAGE_PATH = 'images'  # the path to the folder with the imagesets relative to the filesystem root (see FS_URL)
+TMP_IMAGE_PATH = 'images'  # the path to use for temporary image files relative to the temp filesystem (see TMP_FS_URL)
+TOOLS_PATH = 'tools'  # the path to the folder with the tools relative to the filesystem root (see FS_URL)
+TOOLS_ENABLED = True
+TOOL_UPLOAD_NOTICE = ''
 
 # filename extension of accepted imagefiles
 IMAGE_EXTENSION = {

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ Pillow
 psycopg2-binary
 django-registration
 django-friendly-tag-loader
+fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,21 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+appdirs==1.4.3            # via fs
 confusable-homoglyphs==3.2.0  # via django-registration
-django-friendly-tag-loader==1.3.1
-django-registration==3.0.1
-django-widget-tweaks==1.4.5
-django==2.2.10
-djangorestframework==3.11.0
-fasteners==0.15
+django-friendly-tag-loader==1.3.1  # via -r requirements.in
+django-registration==3.1  # via -r requirements.in
+django-widget-tweaks==1.4.8  # via -r requirements.in
+django==2.2.12            # via -r requirements.in, django-registration, djangorestframework
+djangorestframework==3.11.0  # via -r requirements.in
+fasteners==0.15           # via -r requirements.in
+fs==2.4.11                # via -r requirements.in
 monotonic==1.5            # via fasteners
-pillow==7.0.0
-psycopg2-binary==2.8.4
-pytz==2019.3              # via django
-six==1.13.0               # via fasteners
-sqlparse==0.3.0           # via django
+pillow==7.1.2             # via -r requirements.in
+psycopg2-binary==2.8.5    # via -r requirements.in
+pytz==2020.1              # via django, fs
+six==1.14.0               # via fasteners, fs
+sqlparse==0.3.1           # via django
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
Thanks for creating imagetagger. It's a great tool. I use it together with Google Cloud Storage and I therefore did a rather large refactoring, abstracting the file storage layer of imagetagger.

Now many other filesystems like S3 or GCS are supported through [PyFilesystem2](https://github.com/PyFilesystem/pyfilesystem2) (see [here](https://www.pyfilesystem.org/page/index-of-filesystems) for a list of supported file systems.)

There were no tests for the file storage layer and I did not write any new ones with this refactoring. I did some manual testing and am successfully using this filesystem abstraction in my Google Cloud deployment. Feel free to write some tests yourself. I might also add some later on.

I thought I contribute this potentially useful change back in case it is useful for other people. However, feel free to adapt or completely reject this pull request.

