### PR TITLE
Let nginx determine the image content type

### DIFF
--- a/imagetagger/imagetagger/images/views.py
+++ b/imagetagger/imagetagger/images/views.py
@@ -359,7 +359,9 @@ def view_image(request, image_id):
     file_path = os.path.join(settings.IMAGE_PATH, image.path())
 
     if settings.USE_NGINX_IMAGE_PROVISION:
-        response = HttpResponse(content_type='image')
+        response = HttpResponse()
+        # Let nginx determine the Content-Type
+        del response['Content-Type']
         response['X-Accel-Redirect'] = "/ngx_static_dn/{}".format(image.relative_path())
     else:
         response =  FileResponse(open(file_path, 'rb'), content_type="image")


### PR DESCRIPTION
Currently, the 'Content-Type' header is set to 'image' which is actually invalid and not recognized by nginx. Deleting the header lets nginx determine the correct value of the header.