### PR TITLE
Fix 'NoneType' object has no attribute 'name' on export

### DIFF
--- a/imagetagger/imagetagger/annotations/views.py
+++ b/imagetagger/imagetagger/annotations/views.py
@@ -234,11 +234,11 @@ def export_format(export_format_name, imageset):
 
     placeholders_filename = {
         '%%imageset': imageset.name,
-        '%%team': imageset.team.name,
+        '%%team': imageset.team.name if imageset.team else 'DeletedTeam',
         '%%setlocation': imageset.location,
     }
     for key, value in placeholders_filename.items():
-                        file_name = file_name.replace(key, str(value))
+        file_name = file_name.replace(key, str(value))
 
     min_verifications = export_format.min_verifications
     annotation_counter = 0
@@ -422,7 +422,7 @@ def export_format(export_format_name, imageset):
         '%%content': formatted_content,
         '%%imageset': imageset.name,
         '%%setdescription': imageset.description,
-        '%%team': imageset.team.name,
+        '%%team': imageset.team.name if imageset.team else 'DeletedTeam',
         '%%setlocation': imageset.location,
     }
     for key, value in placeholders_base.items():


### PR DESCRIPTION
When a team is deleted, its image sets are kept, but the team is changed to None. When the annotations of the set are exported, the team name is accessed which results in the above mentioned error. Now, the team name will be replaced with an empty string if the team is None.

Closes #153.