### PR TITLE
Speed up verification view

### DIFF
--- a/imagetagger/imagetagger/annotations/serializers.py
+++ b/imagetagger/imagetagger/annotations/serializers.py
@@ -17,6 +17,19 @@ class AnnotationTypeSerializer(ModelSerializer):
         )
 
 
+class AnnotationListSerializer(ModelSerializer):
+    class Meta:
+        model = Annotation
+        fields = (
+            'id',
+            'annotation_type',
+            'vector',
+            'image',
+        )
+
+    image = ImageSerializer(read_only=True)
+
+
 class AnnotationSerializer(ModelSerializer):
     verified_by_user = SerializerMethodField('is_verified_by_user')
 

--- a/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/verification.js
@@ -24,6 +24,7 @@ function calculateImageScale() {
   let gHeaders;
   let gHideFeedbackTimeout;
   let gAnnotationList;
+  let gAnnotationTypes;
   let gImageId;
   let gImageSet;
   let gImageSetId;
@@ -81,7 +82,9 @@ function calculateImageScale() {
       headers: gHeaders,
       dataType: 'json',
       success: function (data) {
-        displayAnnotationTypeOptions(data.annotation_types);
+        gAnnotationTypes = data.annotation_types;
+        displayAnnotationTypeOptions();
+        loadFilteredAnnotationList(gImageSetId);
       },
       error: function () {
         displayFeedback($('#feedback_connection_error'))
@@ -241,7 +244,10 @@ function calculateImageScale() {
           annotation_text_array.push("'x" + i + "': " + annotation.vector["x" + i] +
               ", 'y" + i + "': " + annotation.vector["y" + i]);
         }
-        link.text(shorten("{" + annotation_text_array.join(', ') + "}"));
+        let annotation_type = gAnnotationTypes.filter(function (e) {
+          return e.id === annotation.annotation_type;
+        })[0].name;
+        link.text(shorten(annotation_type + " {" + annotation_text_array.join(', ') + "}"));
       }
 
       link.data('annotationid', annotation.id);
@@ -273,10 +279,10 @@ function calculateImageScale() {
     }
   }
 
-  function displayAnnotationTypeOptions(annotationTypeList) {
+  function displayAnnotationTypeOptions() {
     // TODO: empty the options?
     let annotationTypeSelect = $('#annotation_type_select');
-    $.each(annotationTypeList, function (key, annotationType) {
+    $.each(gAnnotationTypes, function (key, annotationType) {
       annotationTypeSelect.append($('<option/>', {
         name: annotationType.name,
         value: annotationType.id,
@@ -573,7 +579,6 @@ function calculateImageScale() {
     $('#blurred_label').hide();
     $('#concealed_label').hide();
     loadAnnotationTypeList(gImageSetId);
-    loadFilteredAnnotationList(gImageSetId);
 
     $('#filter_update_btn').on('click', handleFilterSwitchChange);
 


### PR DESCRIPTION
This pull request speeds up the annotation loading of the verification view. It works by changing two things:
1. Only load the information relevant for the annotation list on the left, load the other information later
2. Improve some database queries

In my setup, the loading time of the verification view was significantly sped up. (10 times as fast for 3500 annotations.) This approach might therefore replace the approach suggested in #74.

The second commit adds the annotation type to the annotation list in the verification view.