### PR TITLE
Show all verifications in verification view

### DIFF
--- a/imagetagger/imagetagger/annotations/static/annotations/js/boundingboxes.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/boundingboxes.js
@@ -18,6 +18,18 @@ class BoundingBoxes {
     this.clear();
     calculateImageScale();
     color = color || globals.stdColor;
+    let colors = [];
+    if (color.constructor === Array) {
+      colors = color;
+      if (color.length != annotations.length) {
+        console.log('wrong number of colors');
+        return;
+      }
+    } else {
+      for (let i = 0; i < annotations.length; i++) {
+        colors.push(color);
+      }
+    }
 
     if (annotations.length === 0 || !globals.drawAnnotations) {
       return;
@@ -29,6 +41,7 @@ class BoundingBoxes {
     for (var a in annotations) {
 
       var annotation = annotations[a];
+      let color = colors[a];
       if (annotation.annotation_type.id !== this.annotationTypeId) {
         continue;
       }

--- a/imagetagger/imagetagger/annotations/static/annotations/js/canvas.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/canvas.js
@@ -427,10 +427,26 @@ class Canvas {
   drawExistingAnnotations(annotations, color) {
     this.clear();
     color = color || globals.stdColor;
+    let colors = [];
+    if (color.constructor === Array) {
+      colors = color;
+      if (color.length != annotations.length) {
+        console.log('wrong number of colors');
+        return;
+      }
+    } else {
+      for (let i = 0; i < annotations.length; i++) {
+        colors.push(color);
+      }
+    }
     if (!globals.drawAnnotations) {
       return;
     }
-    for (let annotation of annotations) {
+    for (let i in annotations) {
+      let annotation = annotations[i];
+      let color = colors[i];
+      console.log(annotation);
+      console.log(color);
       if (annotation.annotation_type.id !== this.annotationTypeId) {
         continue;
       }

--- a/imagetagger/imagetagger/annotations/urls.py
+++ b/imagetagger/imagetagger/annotations/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     url(r'^api/annotation/loadsetannotationtypes/$', views.load_set_annotation_types, name='load_set_annotation_types'),  # loads annotations of an image
     url(r'^api/annotation/loadfilteredset/$', views.load_filtered_set_annotations, name='load_filtered_set_annotations'),  # loads filtered annotations of an image
     url(r'^api/annotation/loadone/$', views.load_annotation, name='load_annotation'),
+    url(r'^api/annotation/loadmultiple/$', views.load_multiple_annotations, name='load_multiple_annotations'),
     url(r'^api/annotation/verify/$', views.api_verify_annotation, name='verify_annotation'),
     url(r'^api/annotation/update/$', views.update_annotation, name='update_annotations'),
     url(r'^api/annotation/blurred_concealed/$', views.api_blurred_concealed_annotation, name='blurred_concealed_annotation'),

--- a/imagetagger/imagetagger/annotations/views.py
+++ b/imagetagger/imagetagger/annotations/views.py
@@ -729,7 +729,7 @@ def load_filtered_set_annotations(request) -> Response:
 
     images = Image.objects.filter(image_set=imageset)
     annotations = Annotation.objects.filter(image__in=images,
-                                            annotation_type__active=True).order_by('image_id').select_related()
+                                            annotation_type__active=True).order_by('image__name', 'id').select_related()
     if annotation_type_id > -1:
         annotations = annotations.filter(annotation_type__id=annotation_type_id)
     if verified:

--- a/imagetagger/imagetagger/images/views.py
+++ b/imagetagger/imagetagger/images/views.py
@@ -415,7 +415,7 @@ def view_imageset(request, image_set_id):
     all_annotation_types = AnnotationType.objects.filter(active=True)
     annotations = Annotation.objects.filter(
         image__in=images,
-        annotation_type__active=True).order_by("id")
+        annotation_type__active=True).order_by('image__name', 'id')
     annotation_types = AnnotationType.objects.filter(annotation__image__image_set=imageset, active=True).distinct()\
         .annotate(count=Count('annotation'),
                   in_image_count=Count('annotation', filter=Q(annotation__vector__isnull=False)),


### PR DESCRIPTION
This shows all annotations of the selected type on an image. The annotations that are not currently verified are displayed transparently. This closes #164.