### PR TITLE
use zip for image download as default

### DIFF
--- a/imagetagger/imagetagger/images/templates/images/download.py
+++ b/imagetagger/imagetagger/images/templates/images/download.py
@@ -76,6 +76,11 @@ def download_zip(current_imageset):
                      allow_redirects=False,
                      headers={'referer': BaseUrl},
                      stream=True) as r:
+        # this is intended for the case when an imageset does not exist or the zip does not yet exist
+        if r.status_code == 404:
+            print("In Imageset {} was an error. The server returned page not found.".format(current_imageset))
+            errorlist.append(current_imageset)
+            return
         filepath = os.path.join(filename, current_imageset)
         full_zipname = os.path.join(filepath, current_imageset+".zip")
         with open(full_zipname, "wb") as f:

--- a/imagetagger/imagetagger/images/templates/images/download.py
+++ b/imagetagger/imagetagger/images/templates/images/download.py
@@ -22,7 +22,7 @@ if "--separate" in sys.argv or "-s" in sys.argv:
         sys.argv.remove("-s")
     print("The images will be downloaded separately instead of as zip.")
 if len(sys.argv) < 2:
-    imageset = input("Imagesets you want to download, separated by a ',' or ' ':")
+    imageset = input("Imagesets you want to download, separated by a ',' or ' ': ")
 else:
     if sys.argv[1] == '-h':
         print("This script will download images from the specified imageset for you.")
@@ -90,7 +90,7 @@ def download_zip(current_imageset):
                      stream=True) as r:
         # this is intended for the case when an imageset does not exist or the zip does not yet exist
         if r.status_code == 404:
-            print("In Imageset {} was an error. The server returned page not found.".format(current_imageset))
+            print("In Imageset {} was an error. The server returned page not found. Try --separate if zip download is disabled.".format(current_imageset))
             errorlist.append(current_imageset)
             return
         filepath = os.path.join(filename, current_imageset)
@@ -143,7 +143,7 @@ def download_imageset(current_imageset):
 
 
 for imgset in imagesets:
-    if imgset is not " ":
+    if imgset != " ":
         if not separate_download:
             download_zip(imgset)
         else:

--- a/imagetagger/imagetagger/images/templates/images/download.py
+++ b/imagetagger/imagetagger/images/templates/images/download.py
@@ -12,6 +12,15 @@ except ImportError:
     sys.exit()
 
 BaseUrl = "{{ base_url }}" + "/"
+separate_download = False
+if "--separate" in sys.argv or "-s" in sys.argv:
+    separate_download = True
+    # remove parameters from list
+    if "--separate" in sys.argv:
+        sys.argv.remove("--separate")
+    if "-s" in sys.argv:
+        sys.argv.remove("-s")
+    print("The images will be downloaded separately instead of as zip.")
 if len(sys.argv) < 2:
     imageset = input("Imagesets you want to download, separated by a ',' or ' ':")
 else:
@@ -19,7 +28,9 @@ else:
         print("This script will download images from the specified imageset for you.")
         print("The images will be downloaded from: {}".format(BaseUrl))
         print("If errors occur during the download you will be notified at the end of the script execution")
-        print("Just execute it with ./imagetagger_dl_script.py")
+        print("If you want to download the images separately instead of as a zip (this was done in the past),")
+        print("call the script with ./imagetagger_dl_script.py --separate imgsetID1, imgsetID2")
+        print("Otherwise just execute it with ./imagetagger_dl_script.py")
         sys.exit()
     else:
         imageset = " ".join(sys.argv[1:])
@@ -67,6 +78,7 @@ cookies = {'sessionid': sessionid}
 
 
 def download_zip(current_imageset):
+    print(f"Now downloading {current_imageset}")
     if not os.path.exists(os.path.join(os.getcwd(), filename, current_imageset)):
         os.makedirs(os.path.join(os.getcwd(), filename, current_imageset))
     ziplink = f"{BaseUrl}images/imageset/{current_imageset}/download/"
@@ -132,7 +144,10 @@ def download_imageset(current_imageset):
 
 for imgset in imagesets:
     if imgset is not " ":
-        download_zip(imgset)
+        if not separate_download:
+            download_zip(imgset)
+        else:
+            download_imageset(imgset)
 if errorlist:
     print("There have been errors while downloading the following imagesets: ")
     for item in errorlist:

--- a/imagetagger/imagetagger/images/templates/images/download.py
+++ b/imagetagger/imagetagger/images/templates/images/download.py
@@ -46,13 +46,11 @@ if error:
 error = False
 
 loginpage = requests.get(BaseUrl)
-csrftoken = loginpage.cookies['csrftoken']
 
-cookies = {'csrftoken': csrftoken}
-csrfmiddlewaretoken = csrftoken
+cookies = {'csrftoken': loginpage.cookies['csrftoken']}
 data = {'username': user,
         'password': password,
-        'csrfmiddlewaretoken': csrfmiddlewaretoken}
+        'csrfmiddlewaretoken': loginpage.cookies['csrftoken']}
 loggedinpage = requests.post(
     '{}user/login/'.format(BaseUrl),
     data=data,

--- a/imagetagger/imagetagger/images/templates/images/download.py
+++ b/imagetagger/imagetagger/images/templates/images/download.py
@@ -88,6 +88,9 @@ def download_zip(current_imageset):
 
 # Download images individually. This is slower than downloading the zip, so the zip is used by default.
 def download_imageset(current_imageset):
+    error = False
+    if not os.path.exists(os.path.join(os.getcwd(), filename, current_imageset)):
+        os.makedirs(os.path.join(os.getcwd(), filename, current_imageset))
     page = requests.get("{}images/imagelist/{}/".format(BaseUrl,
                         current_imageset),
                         cookies=cookies)


### PR DESCRIPTION
Currently the images are downloaded individually by default. This is slow.
This pull request replaces this behavior by downloading the zip file for the imageset instead. This works significantly faster (in my experiments).

Currently the other method for downloading is still included in the download script, in case the zip download does not work. This way it is just a single line to replace to go back to the previous behavior.

Closes #159 