### PR TITLE
Fix problems with email settings

### DIFF
--- a/imagetagger/imagetagger/settings.py
+++ b/imagetagger/imagetagger/settings.py
@@ -229,3 +229,4 @@ class Prod(Base):
     EMAIL_PORT = values.Value(environ_prefix='IT')
     EMAIL_HOST_USER = values.Value(environ_prefix='IT')
     EMAIL_HOST_PASSWORD = values.Value(environ_prefix='IT')
+    DEFAULT_FROM_EMAIL = values.Value(environ_prefix='IT')

--- a/imagetagger/imagetagger/users/templates/registration/password_reset_subject.txt
+++ b/imagetagger/imagetagger/users/templates/registration/password_reset_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}[{{ site.name }}] {% trans 'Pasword Reset' %}
+{% load i18n %}[{{ site_name }}] {% trans 'Pasword Reset' %}


### PR DESCRIPTION
The DEFAULT_FROM_EMAIL was not set in production, this led to invalid sender email addresses. Also, the variable `site.name` had to be changed to `site_name` in the subject; I don't know why.