### PR TITLE
Disable annotation cache

### DIFF
--- a/imagetagger/imagetagger/annotations/static/annotations/js/boundingboxes.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/boundingboxes.js
@@ -380,8 +380,8 @@ class BoundingBoxes {
     // array with all matching annotations
     var matchingAnnotations = [];
 
-    for (var a in globals.currentAnnotations) {
-      var annotation = globals.currentAnnotations[a];
+    for (var a in globals.currentAnnotationsOfSelectedType) {
+      var annotation = globals.currentAnnotationsOfSelectedType[a];
       if (annotation.annotation_type.id !== annotationType) {
         continue;
       }


### PR DESCRIPTION
This PR disables the annotation cache because with the cache, more network requests are made than without the cache... Also `globals.currentAnnotations` is renamed to `globals.currentAnnotationsOfSelectedType` and removes `globals.allAnnotations` so that I hopefully don't fall into despair again the next time I am trying to understand the difference between `globals.allAnnotations`, `globals.currentAnnotations`, `gAllAnnotations` and `gCurrentAnnotations`.