### PR TITLE
Skip keep selection for next for multilines

### DIFF
--- a/imagetagger/imagetagger/annotations/static/annotations/js/canvas.js
+++ b/imagetagger/imagetagger/annotations/static/annotations/js/canvas.js
@@ -589,6 +589,9 @@ class Canvas {
         blurredP.hide();
         blurred.prop('checked', false);
         blurred.prop('disabled', true);
+      } else if (globals.restoreSelectionVectorType === 4) {
+        // this is not implemented for multilines, so just do nothing
+        this.old = undefined;
       } else {
         let vector = {};
         for (let key in globals.restoreSelection) {


### PR DESCRIPTION
Keep selection for next for multilines was never implemented but badly treated. This is now better.