### PR TITLE
Add image id to export format

### DIFF
--- a/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/annotation.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/annotation.html
@@ -5,6 +5,7 @@
     <p><b>%%imagewidth:</b> width of the image</p>
     <p><b>%%imageheight:</b> height of the image </p>
     <p><b>%%imageset:</b> name of the imageset </p>
+    <p><b>%%imageid:</b> id of the image (guaranteed to be unique)</p>
     <p><b>%%type:</b> annotation type</p>
     <p><b>%%veriamount:</b> the amount of verifications for the annotation</p>
     <p><b>%%vector:</b> the annotation vector, as defined in the vector format</p>

--- a/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/image.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/image.html
@@ -5,6 +5,7 @@
     <p><b>%%imagewidth:</b> width of the image</p>
     <p><b>%%imageheight:</b> height of the image</p>
     <p><b>%%imageset:</b> name of the imageset</p>
+    <p><b>%%imageid:</b> the id of the image (guaranteed to be unique for each image)</p>
     <p><b>%%annoamount:</b> number of annotations for the image </p>
     <p><b>%%annotations:</b> the content of the annotation format and the not in image format</p>
 {% endblocktrans %}

--- a/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/not_in_image.html
+++ b/imagetagger/imagetagger/annotations/templates/annotations/export_format_legends/not_in_image.html
@@ -5,6 +5,7 @@
     <p><b>%%imagewidth:</b> width of the image</p>
     <p><b>%%imageheight:</b> height of the image</p>
     <p><b>%%imageset:</b> name of the imageset </p>
+    <p><b>%%imageid:</b> id of the image (guaranteed to be unique)</p>
     <p><b>%%type:</b> type of the annotation</p>
     <p><b>%%veriamount:</b> the amount of verifications for the annotation</p>
 {% endblocktrans %}

--- a/imagetagger/imagetagger/annotations/views.py
+++ b/imagetagger/imagetagger/annotations/views.py
@@ -266,6 +266,7 @@ def export_format(export_format_name, imageset):
                             '%%imagewidth': annotation.image.width,
                             '%%imageheight': annotation.image.height,
                             '%%imagename': image.name,
+                            '%%imageid': image.id,
                             '%%type': annotation.annotation_type.name,
                             '%%veriamount': annotation.verification_difference,
                         }
@@ -295,6 +296,7 @@ def export_format(export_format_name, imageset):
                             '%%imagewidth': image.width,
                             '%%imageheight': image.height,
                             '%%imagename': image.name,
+                            '%%imageid': image.id,
                             '%%type': annotation.annotation_type.name,
                             '%%veriamount': annotation.verification_difference,
                             '%%vector': formatted_vector,
@@ -332,6 +334,7 @@ def export_format(export_format_name, imageset):
                     '%%imagewidth': image.width,
                     '%%imageheight': image.height,
                     '%%imagename': image.name,
+                    '%%imageid': image.id,
                     '%%annotations': annotation_content,
                     '%%annoamount': annotations.count(),
                 }
@@ -358,6 +361,7 @@ def export_format(export_format_name, imageset):
                     '%%imagewidth': annotation.image.width,
                     '%%imageheight': annotation.image.height,
                     '%%imagename': annotation.image.name,
+                    '%%imageid': annotation.image.id,
                     '%%type': annotation.annotation_type.name,
                     '%%veriamount': annotation.verification_difference,
                 }
@@ -387,6 +391,7 @@ def export_format(export_format_name, imageset):
                     '%%imagewidth': annotation.image.width,
                     '%%imageheight': annotation.image.height,
                     '%%imagename': annotation.image.name,
+                    '%%imageid': annotation.image.id,
                     '%%type': annotation.annotation_type.name,
                     '%%veriamount': annotation.verification_difference,
                     '%%vector': formatted_vector,


### PR DESCRIPTION
This adds the image id as `%%imageid` to the export format.